### PR TITLE
feat: add mobile nav bar

### DIFF
--- a/src/app/(content)/profile/page.tsx
+++ b/src/app/(content)/profile/page.tsx
@@ -6,13 +6,16 @@ import { BlockList } from "~/features/profile/components/BlockList";
 import { ClassList } from "~/features/profile/components/ClassList";
 import { ProfileDetailsForm } from "~/features/profile/components/ProfileDetailsForm";
 import { ProfileHeader } from "~/features/profile/components/ProfileHeader";
+import MobileNavBar from "~/components/layout/MobileNavBar";
 
 export default function ProfilePage() {
   const { user } = useUser();
   const userId = user?.emailAddresses[0]?.emailAddress;
 
   return (
-    <div className="profile-page-panel">
+    <>
+    <MobileNavBar />
+    <div className="p-4 font-sans w-full lg:w-1/3">
       <ConfirmProvider>
         <ProfileHeader user={user} />
         <ProfileDetailsForm userId={userId} />
@@ -21,5 +24,6 @@ export default function ProfilePage() {
         <br />
       </ConfirmProvider>
     </div>
+    </>
   );
 }

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -1,0 +1,131 @@
+"use client";
+import darkLogo from "~/image/darkLogo2.png";
+import lightLogo from "~/image/lightLogo2.png";
+import { Fragment, useState } from "react";
+import { usePathname } from "next/navigation";
+import { SignOutButton, useUser } from "~/lib/auth-client";
+import { Menu, X } from "lucide-react";
+import Image from "next/image";
+import { useUserTheme } from "~/features/profile/hooks/useUserTheme";
+
+export default function MobileNavBar() {
+  const { user } = useUser();
+  const userId = user?.emailAddresses[0]?.emailAddress;
+  const pathname = usePathname();
+  const page = pathname.split("/")[1];
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { theme, toggleTheme } = useUserTheme(userId);
+
+  return (
+    <Fragment>
+        <nav className="mobile-nav-bar md:hidden">
+            <a href="/feed" className="flex items-center">
+                <Image
+                  className="hidden dark:block h-8 w-auto"
+                  src={darkLogo}
+                  alt="dark-mode-logo"
+                  width={150}
+                  height={75}
+                />
+                <Image
+                  className="block dark:hidden h-8 w-auto"
+                  src={lightLogo}
+                  alt="light-mode-logo"
+                  width={150}
+                  height={75}
+                />
+            </a>
+
+            <button
+              type="button"
+              aria-label={isDrawerOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={isDrawerOpen}
+              aria-controls="mobile-nav-list"
+              onClick={() => setIsDrawerOpen(!isDrawerOpen)}
+              className="p-2"
+            >
+              {isDrawerOpen ? <X size={24} /> : <Menu size={24} />}
+            </button>
+        </nav>
+
+        {/* Dropdown list */}
+        <div
+            id="mobile-nav-list"
+            aria-hidden={!isDrawerOpen}
+            className={`mobile-nav-list ${isDrawerOpen ? "max-h-80 opacity-100 translate-y-0" : "max-h-0 opacity-0 -translate-y-2"}`}
+        >
+            <ul className="flex flex-col gap-2">
+                <li>
+                    <a
+                        href="/feed"
+                        onClick={() => setIsDrawerOpen(false)}
+                        className="nav-link"
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                    >
+                        Group Finder
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href="/my-groups"
+                        onClick={() => setIsDrawerOpen(false)}
+                        className='nav-link'
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                    >
+                        My Groups
+                    </a>
+                </li>
+                <li>
+                    <a
+                        href="/profile"
+                        onClick={() => setIsDrawerOpen(false)}
+                        className='nav-link'
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                    >
+                        My Profile
+                    </a>
+                    <SignOutButton>
+                        <button 
+                            type="button" 
+                            tabIndex={isDrawerOpen ? 0 : -1}
+                            className="nav-link text-xs dark:text-white mb-4 px-4"
+                        >
+                            Logout
+                        </button>
+                    </SignOutButton>
+                </li>
+                <li className="grid grid-cols-3">
+                    <button
+                        onClick={toggleTheme}
+                        className="mb-4 w-full text-xs dark:text-white block"
+                        id="mode"
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                    >
+                        {theme === "light" ? "Dark Mode" : "Light Mode"}
+                    </button>
+                    <a
+                        href="https://forms.gle/MEQ7miCZCrC48P6y8"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                        className="block w-full text-center text-xs dark:text-white"
+                    >
+                        Feedback
+                    </a>
+                    <a
+                        href="/privacy"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        tabIndex={isDrawerOpen ? 0 : -1}
+                        className={`w-full rounded-lg pb-2 text-center text-xs ${page === "privacy" ? "font-bold text-lightSelected dark:text-darkSelected" : " text-black dark:text-white"}`}
+                    >
+                        Privacy Policy
+                    </a>
+                </li>
+            </ul>
+        </div>
+        
+        
+    </Fragment>
+  );
+}

--- a/src/components/layout/NavBar.tsx
+++ b/src/components/layout/NavBar.tsx
@@ -1,13 +1,11 @@
 "use client";
 import darkLogo from "~/image/darkLogo2.png";
 import lightLogo from "~/image/lightLogo2.png";
-import { Fragment, useState } from "react";
+import { Fragment } from "react";
 import CreateGroupModal from "~/features/groups/components/CreateGroupModal";
 import { usePathname } from "next/navigation";
 import { useUser } from "~/lib/auth-client";
-import { Menu, X } from "lucide-react";
 import Image from "next/image";
-import { ProfileMenu } from "~/components/ui/ProfileMenu";
 import { useUserTheme } from "~/features/profile/hooks/useUserTheme";
 
 export default function NavBar() {
@@ -15,7 +13,6 @@ export default function NavBar() {
   const userId = user?.emailAddresses[0]?.emailAddress;
   const pathname = usePathname();
   const page = pathname.split("/")[1];
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const { theme, toggleTheme } = useUserTheme(userId);
 
   return (
@@ -25,20 +22,6 @@ export default function NavBar() {
           {/* Top Section */}
           <div>
             <div className="flex w-full flex-row items-center">
-              <button
-                onClick={() => setIsDrawerOpen(!isDrawerOpen)}
-                className="mr-auto md:hidden"
-                type="button"
-                aria-label={
-                  isDrawerOpen
-                    ? "Close navigation menu"
-                    : "Open navigation menu"
-                }
-                aria-expanded={isDrawerOpen}
-                aria-controls="mobile-navigation-menu"
-              >
-                {isDrawerOpen ? <X size={24} /> : <Menu size={24} />}
-              </button>
               {/* Hide content after first button on small screens */}
               <a href="/feed" className="hidden h-[50px] items-center md:flex">
                 <Image
@@ -103,93 +86,6 @@ export default function NavBar() {
           </div>
         </div>
       </div>
-
-      {/* Drawer Menu */}
-      {isDrawerOpen && (
-        <div
-          className="mobile-drawer-backdrop"
-          onClick={() => setIsDrawerOpen(false)}
-        >
-          <div
-            id="mobile-navigation-menu"
-            className="mobile-drawer-panel"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div>
-              <button
-                onClick={() => setIsDrawerOpen(false)}
-                className="mb-4 text-black dark:text-white"
-                type="button"
-                aria-label="Close navigation menu"
-              >
-                <X size={24} />
-              </button>
-              <a href="/feed">
-                <Image
-                  className="hidden dark:block"
-                  src={darkLogo}
-                  alt="dark-mode-logo"
-                  width={150}
-                  height={75}
-                />
-                <Image
-                  className="block dark:hidden"
-                  src={lightLogo}
-                  alt="light-mode-logo"
-                  width={150}
-                  height={75}
-                />
-              </a>
-              <nav className="flex flex-col gap-y-4">
-                <a
-                  href="/feed"
-                  className={`py-2 ${page === "feed" ? "font-bold text-lightSelected dark:text-darkSelected" : "text-black dark:text-white"}`}
-                >
-                  Group Finder
-                </a>
-                <a
-                  href="/my-groups"
-                  className={
-                    page === "my-groups"
-                      ? "font-bold text-lightSelected dark:text-darkSelected"
-                      : "text-black dark:text-white"
-                  }
-                >
-                  My Groups
-                </a>
-                <button
-                  onClick={toggleTheme}
-                  className="modeButton rounded-lg bg-darkbg text-lightbg dark:bg-lightbg dark:text-darkbg"
-                  id="mode"
-                >
-                  {theme === "light" ? "Dark Mode" : "Light Mode"}
-                </button>
-                <ProfileMenu containerClassName="drawer-profile-menu-container" />
-              </nav>
-            </div>
-
-            {/* Feedback Button */}
-            <div className="pb-4">
-              <a
-                href="https://forms.gle/MEQ7miCZCrC48P6y8"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="feedback-link"
-              >
-                Feedback
-              </a>
-              <a
-                href="/privacy"
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`w-full rounded-lg pb-2 text-center text-xs underline ${page === "privacy" ? "font-bold text-lightSelected dark:text-darkSelected" : "text-black dark:text-white"}`}
-              >
-                Privacy Policy
-              </a>
-            </div>
-          </div>
-        </div>
-      )}
 
       <CreateGroupModal />
     </Fragment>

--- a/src/features/groups/components/FilterBar.tsx
+++ b/src/features/groups/components/FilterBar.tsx
@@ -2,6 +2,7 @@ import Select, { type MultiValue, type StylesConfig } from "react-select";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { ProfileMenu } from "~/components/ui/ProfileMenu";
+import MobileNavBar from "~/components/layout/MobileNavBar";
 
 type FilterOption = { value: string; label: string };
 
@@ -60,33 +61,36 @@ function TopFilterBar({
   setSelectedDate,
 }: TopFilterBarProps) {
   return (
-    <div className="filter-bar">
-      <div className="filter-controls">
-        <Select
-          isMulti
-          options={courseOptions}
-          value={selectedCourses}
-          onChange={setSelectedCourses}
-          classNamePrefix="react-select"
-          className="filter-course-select"
-          placeholder="Courses"
-          styles={customSelectStyles}
-          components={customSelectComponents}
-        />
-
-        <div className="filter-date-control">
-          <DatePicker
-            selected={selectedDate}
-            onChange={(date) => setSelectedDate(date)}
-            customInput={<input />}
-            popperClassName="custom-popper"
-            wrapperClassName="filter-date-wrapper"
-            placeholderText="Date"
-            className="filter-date-input"
+    <div className="top-bar">
+      <MobileNavBar />
+      <div className="filter-bar">      
+        <div className="filter-controls">
+          <Select
+            isMulti
+            options={courseOptions}
+            value={selectedCourses}
+            onChange={setSelectedCourses}
+            classNamePrefix="react-select"
+            className="filter-course-select"
+            placeholder="Courses"
+            styles={customSelectStyles}
+            components={customSelectComponents}
           />
-        </div>
 
-        <ProfileMenu />
+          <div className="filter-date-control">
+            <DatePicker
+              selected={selectedDate}
+              onChange={(date) => setSelectedDate(date)}
+              customInput={<input />}
+              popperClassName="custom-popper"
+              wrapperClassName="filter-date-wrapper"
+              placeholderText="Date"
+              className="filter-date-input"
+            />
+          </div>
+
+          <ProfileMenu />
+        </div>
       </div>
     </div>
   );

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -30,6 +30,15 @@
   @apply grid h-screen grid-rows-[auto,1fr,auto] gap-y-6 overflow-hidden bg-lightbg px-4 pt-[50px] text-black dark:bg-darkbg dark:text-white md:bg-lightSidebar md:dark:bg-darkSidebar;
 }
 
+.mobile-nav-bar {
+  width: calc(100% + 1rem);
+  @apply sticky top-0 z-10 flex items-center justify-between px-6 py-3  px-4 py-3 text-left font-medium text-black transition-colors bg-lightSidebar dark:bg-darkSidebar focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lightSelected dark:text-white dark:focus-visible:ring-darkSelected w-full;
+}
+
+.mobile-nav-list {
+  @apply md:hidden overflow-hidden transition-all duration-300 ease-in-out transform bg-lightSidebar dark:bg-darkSidebar;
+}
+
 .nav-link {
   width: calc(100% + 1rem);
   @apply block rounded-lg px-4 py-3 text-left font-medium text-black transition-colors hover:bg-lightAccent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-lightSelected dark:text-white dark:hover:bg-darkAccent dark:focus-visible:ring-darkSelected;
@@ -108,8 +117,12 @@
   @apply truncate;
 }
 
+.top-bar {
+  @apply sticky top-0 z-10;
+}
+
 .filter-bar {
-  @apply sticky top-0 z-10 w-full border-b border-b-darkbg bg-lightbg px-6 pb-4 pt-6 dark:border-b-lightbg dark:bg-darkbg;
+  @apply  w-full border-b border-b-darkbg bg-lightbg px-6 pb-4 pt-6 dark:border-b-lightbg dark:bg-darkbg;
 }
 
 .filter-controls {


### PR DESCRIPTION
Notes:
Currently it is implemented as a separate component within TopFilterBar as a shortcut to get the mobile menu live.
Will need to integrate it within NavBar component and remove from FilterBar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a responsive mobile navigation bar with branding, menu controls, navigation links, theme switching, feedback, privacy, and profile access.
  - Added animated drawer open/close behavior and automatic closing after selecting primary links.
  - Added sticky mobile navigation and top-bar layouts for improved page access while scrolling.

- **Improvements**
  - Simplified desktop navigation by separating mobile menu behavior.
  - Improved responsive spacing, typography, and content layout on profile pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->